### PR TITLE
Bump snakeyaml dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 
     implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("org.dom4j:dom4j:2.1.3")
-    implementation("org.yaml:snakeyaml:1.30")
+    implementation("org.yaml:snakeyaml:1.31")
     implementation("xerces:xercesImpl:2.12.2")
 
     testImplementation(kotlin("test"))


### PR DESCRIPTION
There's [a security vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25857) in the snakeyaml plugin before 1.31. I'd appreciate it if we could bump the dependency and release a new version :)