### PR TITLE
POM parsing: replace Xerces dependency with JDK built-in XML parser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 
     implementation("org.dom4j:dom4j:2.1.4")
     implementation("org.yaml:snakeyaml:2.0")
-    implementation("xerces:xercesImpl:2.12.2")
 
     testImplementation(kotlin("test"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/src/main/kotlin/com/namics/oss/gradle/license/DependencyAnalyser.kt
+++ b/src/main/kotlin/com/namics/oss/gradle/license/DependencyAnalyser.kt
@@ -23,7 +23,7 @@
  */
 package com.namics.oss.gradle.license
 
-import org.apache.xerces.jaxp.SAXParserImpl
+import javax.xml.parsers.SAXParserFactory
 import org.dom4j.Element
 import org.dom4j.io.SAXReader
 import org.gradle.api.Project
@@ -90,12 +90,13 @@ public class DependencyAnalyser(val project: Project,
     fun findLicenses(pomFile: File): List<License> {
         try {
 
-            val parser = SAXParserImpl.JAXPSAXParser()
-            parser.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            parser.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            parser.setFeature("http://xml.org/sax/features/namespaces", false);
-            parser.setFeature("http://xml.org/sax/features/namespace-prefixes", false);
-            val reader = SAXReader(parser, false)
+            val parserFactory = SAXParserFactory.newInstance()
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            parserFactory.setNamespaceAware(false);
+
+            val saxParser = parserFactory.newSAXParser()
+            val reader = SAXReader(saxParser.xmlReader, false)
             val doc = reader.read(pomFile)
 
             if (ANDROID_SUPPORT_GROUP_ID == doc?.rootElement?.element("group")?.text) {


### PR DESCRIPTION
This PR removes the XercesImpl dependency.
DependencyAnalyser now instead uses the JDK internal XML parser factory which can be used as a drop-in replacement to the Xerces project.

Rationale behind this change is that Gradle 8.4 requires recent XML parsers and fails with the old XercesImpl dependency on the classpath. There is a workaround that allows Gradle to use the JDK internal parsers:
https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#xml_parsing_now_requires_recent_parsers 

While Gradle itself can be worked around to not use XercesImpl using the system properties, we found that other plugins have also compatiblitity issues with the XercesImpl dependency. For example newer versions of CycloneDX are not compatible as they implicitly expect to find the JDKs latest implementation and support for feature flags. 

Replacing the Xerces dependency with JDK built-in XML parser should avoid all kinds of compatiblity workarounds.
Also, since the Xerces2-J last released in 2022, relying on the maintained JDK internals seems like the more robust way forward.